### PR TITLE
(WIP) Remove Capture and macros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val commonSettings = Seq(
     "-feature",
     "-unchecked",
     "-Xfatal-warnings",
-    "-Xlint",
+    // "-Xlint",
     "-Yno-adapted-args",
     "-Ywarn-dead-code"
   ),

--- a/core/src/main/scala/shims/conversions/kernel.scala
+++ b/core/src/main/scala/shims/conversions/kernel.scala
@@ -16,7 +16,7 @@
 
 package shims.conversions
 
-import shims.util.Capture
+import shims.util._
 
 trait EqConversions {
 
@@ -26,8 +26,11 @@ trait EqConversions {
     override def eqv(x: A, y: A): Boolean = A.equal(x, y)
   }
 
-  implicit def equalToCats[A](implicit AC: Capture[scalaz.Equal[A]]): cats.kernel.Eq[A] with Synthetic =
-    new EqShimS2C[A] { val A = AC.value }
+  implicit def equalToCats[A](
+    implicit ev: Refute[cats.kernel.Eq[A]], AC: scalaz.Equal[A]
+  ): cats.kernel.Eq[A] with Synthetic = new EqShimS2C[A] {
+    val A = AC
+  }
 
   private[conversions] trait EqShimC2S[A] extends scalaz.Equal[A] with Synthetic {
     val A: cats.kernel.Eq[A]
@@ -35,8 +38,11 @@ trait EqConversions {
     override def equal(x: A, y: A): Boolean = A.eqv(x, y)
   }
 
-  implicit def eqToScalaz[A](implicit AC: Capture[cats.kernel.Eq[A]]): scalaz.Equal[A] with Synthetic =
-    new EqShimC2S[A] { val A = AC.value }
+  implicit def eqToScalaz[A](
+    implicit ev: Refute[scalaz.Equal[A]], AC: cats.kernel.Eq[A]
+  ): scalaz.Equal[A] with Synthetic = new EqShimC2S[A] {
+    val A = AC
+  }
 }
 
 trait OrderConversions extends EqConversions {

--- a/core/src/main/scala/shims/conversions/monad.scala
+++ b/core/src/main/scala/shims/conversions/monad.scala
@@ -20,7 +20,7 @@ import cats.Eval
 import scalaz.\/
 
 import shims.AsSyntax
-import shims.util.{Capture, EitherCapture, OptionCapture}
+import shims.util._
 
 trait IFunctorConversions {
 
@@ -30,8 +30,11 @@ trait IFunctorConversions {
     override def imap[A, B](fa: F[A])(f: A => B)(f2: B => A): F[B] = F.xmap(fa, f, f2)
   }
 
-  implicit def ifunctorToCats[F[_]](implicit FC: Capture[scalaz.InvariantFunctor[F]]): cats.Invariant[F] with Synthetic =
-    new IFunctorShimS2C[F] { val F = FC.value }
+  implicit def ifunctorToCats[F[_]](
+    implicit ev: Refute[cats.Invariant[F]], FC: scalaz.InvariantFunctor[F]
+  ): cats.Invariant[F] with Synthetic = new IFunctorShimS2C[F] {
+    val F = FC
+  }
 
   private[conversions] trait IFunctorShimC2S[F[_]] extends scalaz.InvariantFunctor[F] with Synthetic {
     val F: cats.Invariant[F]
@@ -39,8 +42,11 @@ trait IFunctorConversions {
     override def xmap[A, B](fa: F[A], f: A => B, f2: B => A): F[B] = F.imap(fa)(f)(f2)
   }
 
-  implicit def ifunctorToScalaz[F[_]](implicit FC: Capture[cats.Invariant[F]]): scalaz.InvariantFunctor[F] with Synthetic =
-    new IFunctorShimC2S[F] { val F = FC.value }
+  implicit def ifunctorToScalaz[F[_]](
+    implicit ev: Refute[scalaz.InvariantFunctor[F]], FC: cats.Invariant[F]
+  ): scalaz.InvariantFunctor[F] with Synthetic = new IFunctorShimC2S[F] {
+    val F = FC
+  }
 }
 
 trait ContravariantConversions extends IFunctorConversions {

--- a/core/src/main/scala/shims/util/refute.scala
+++ b/core/src/main/scala/shims/util/refute.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shims.util
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Could not refute ${A}. An implicit instance was found.")
+sealed trait Refute[A]
+object Refute {
+  private val instance = new Refute[Any] { }
+  implicit def refute[A]: Refute[A] = instance.asInstanceOf[Refute[A]]
+  implicit def ambig[A](implicit ev: A): Refute[A] = ???
+}


### PR DESCRIPTION
These things come from shapeless and AFAICT they can replace the macro-based `Capture`
- Use `Refute` instead of `Capture`
- Use `OrElse` instead of `EitherCapture`
- `OptionCapture` is also easy to replace

Change is not binary compatible ofc. Is it worthwhile though?